### PR TITLE
Allow pushing gem to any host

### DIFF
--- a/integration_test_kit.gemspec
+++ b/integration_test_kit.gemspec
@@ -14,15 +14,6 @@ Gem::Specification.new do |spec|
   spec.description = 'Integration Test Kit provides a small DSL for defining integration test commands, and an endpoint for calling them locally.'
   spec.license     = 'MIT'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
-
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_dependency 'rails', '~> 5.1.6'


### PR DESCRIPTION
* This is required to allow pushing to RubyGems. 
* We can choose to limit which hosts can be pushed to, but since the code will be public, I don't think there's any purpose. 