### PR TITLE
Open up gemspec to use any version of rails 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     integration_test_kit (0.1.2)
-      rails (>= 5.0.0)
+      rails (~> 5.1.6)
 
 GEM
   remote: https://rubygems.org/
@@ -63,7 +63,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nio4r (2.5.2)
+    nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     rack (2.0.7)
@@ -114,7 +114,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    integration_test_kit (0.1.2)
-      rails (~> 5.1.6)
+    integration_test_kit (0.1.3)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     integration_test_kit (0.1.2)
-      rails (~> 5.1.6)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -63,7 +63,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nio4r (2.5.1)
+    nio4r (2.5.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     rack (2.0.7)
@@ -114,7 +114,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/integration_test_kit.gemspec
+++ b/integration_test_kit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  spec.add_dependency 'rails', '~> 5.1.6'
+  spec.add_dependency 'rails', '~> 5.0'
 
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-rails', '~> 3.8'

--- a/integration_test_kit.gemspec
+++ b/integration_test_kit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  spec.add_dependency 'rails', '~> 5.0'
+  spec.add_dependency 'rails', '>= 5.0.0'
 
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-rails', '~> 3.8'

--- a/integration_test_kit.gemspec
+++ b/integration_test_kit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  spec.add_dependency 'rails', '>= 5.0.0'
+  spec.add_dependency 'rails', '~> 5.0'
 
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-rails', '~> 3.8'

--- a/lib/integration_test_kit/version.rb
+++ b/lib/integration_test_kit/version.rb
@@ -1,3 +1,3 @@
 module IntegrationTestKit
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
We need to bump our rails version due to vulnerabilities in the gemfile on zadev, but `integration_test_kit` is a blocker - this opens up it's dependencies to be satisfied by any version of Rails 5